### PR TITLE
Update view.js

### DIFF
--- a/core/modules/slider/sliderInstance/view.js
+++ b/core/modules/slider/sliderInstance/view.js
@@ -156,22 +156,21 @@ var obj_classdef = 	{
                 var el_navigationDot = new Element('span.navigation-dot').setProperty('data-misc-slide', int_slideKey);
 
                 var slideElement = this.els_items[int_slideKey];
-                var contentContainer = slideElement.getElement('a');
 
-                if (contentContainer) {
-                    var firstChildElement = contentContainer ? contentContainer.getFirst() : null;
+		// Look for a picture or img element anywhere within the slide, prioritizing picture
+		var pictureElement = slideElement.querySelector('picture') || slideElement.querySelector('img');
 
-                    if (firstChildElement) {
+                if (pictureElement) {
+		    var clonedElement = pictureElement.cloneNode(true);
 
-                        var clonedElement = firstChildElement.cloneNode(true);
-                        el_navigationDot.append(clonedElement);
-
-                        if (bln_useDotNavigationImages) {
-                            el_navigationDot.addClass('use-image');
-                            clonedElement.setStyles({
-                                'pointer-events': 'none',
-                            });
-                        }
+                    var clonedElement = firstChildElement.cloneNode(true);
+                    el_navigationDot.append(clonedElement);
+			
+                    if (bln_useDotNavigationImages) {
+                        el_navigationDot.addClass('use-image');
+                        clonedElement.setStyles({
+                            'pointer-events': 'none',
+                        });
                     }
                 }
 

--- a/core/modules/slider/sliderInstance/view.js
+++ b/core/modules/slider/sliderInstance/view.js
@@ -157,13 +157,12 @@ var obj_classdef = 	{
 
                 var slideElement = this.els_items[int_slideKey];
 
-		// Look for a picture or img element anywhere within the slide, prioritizing picture
-		var pictureElement = slideElement.querySelector('picture') || slideElement.querySelector('img');
+		        // Look for a picture or img element anywhere within the slide, prioritizing picture
+		        var pictureElement = slideElement.querySelector('picture') || slideElement.querySelector('img');
 
                 if (pictureElement) {
-		    var clonedElement = pictureElement.cloneNode(true);
+		            var clonedElement = pictureElement.cloneNode(true);
 
-                    var clonedElement = firstChildElement.cloneNode(true);
                     el_navigationDot.append(clonedElement);
 			
                     if (bln_useDotNavigationImages) {


### PR DESCRIPTION
Der Slider soll bzgl. der Vorschaubilder so flexibel sein, dass er Vorschaubilder auch dann entdeckt, wenn sie innerhalb eines Slides tiefer verschachtelt enthalten sind. Dabei sollen bevorzugt picture-Elemente und, falls diese nicht vorhanden sind, stattdessen img-Elemente verwendet werden. Gibt es mehrere Elemente, so soll das erste verwendet werden.

Der aktuelle Lösungsansatz in [fix-slider-thumbnail-bug](https://github.com/leadingsystems/lsjs/pull/28/files) erwartet scheinbar zwingend ein "a"-Element, was ein Slider selbst mit enthaltenem Bild nicht unbedingt haben muss. Und er clont das erste Kind-Element innerhalb eines gefundenen "a"-Elements selbst dann, wenn es überhaupt kein Bild ist.

Damit ist der aktuelle Lösungsansatz nicht geeignet.

In diesem PR zeige ich, wie ich es mir vorstelle. Funktioniert wahrscheinlich direkt, ist aber nicht getestet.

@superMi88 Bitte testen und, sofern funktionsfähig, übernehmen oder ggf. noch anpassen.