### PR TITLE
Behebt Freeze durch bubbled transitionend-Events in Sticky-Header

### DIFF
--- a/core/modules/stickyHeader/view.js
+++ b/core/modules/stickyHeader/view.js
@@ -247,7 +247,7 @@ var obj_classdef = 	{
 					 */
 					window.setTimeout(
 						function() {
-							this.determineSizesAndPositions;
+							this.determineSizesAndPositions();
 							this.__view.handleSubscrolling();
 						}.bind(this),
 						this.int_timeToWaitForRecalculationsAfterHeaderClickInMs
@@ -259,7 +259,11 @@ var obj_classdef = 	{
 
 			this.el_header.addEventListener(
 				'transitionend',
-				function() {
+				function(event) {
+					if (event.target !== this.el_header) {
+						return;
+					}
+
 					if (this.el_body.hasClass(this.obj_classes.moveout)) {
 						this.__view.untouchHeaderIfNecessary();
 					}


### PR DESCRIPTION
Auf Seiten mit großem Header-/Mega-Nav-DOM kann Chrome beim Zoomen tausende bubbled transitionend-Events von Nachfahren-Elementen auslösen. Der stickyHeader-Listener behandelte jedes dieser Events und rief jeweils determineSizesAndPositions() auf. Dadurch wurde die gesamte Header-Subtree wiederholt layoutet und der Main Thread für viele Sekunden blockiert.

transitionend nur noch verarbeiten, wenn event.target das Sticky- Header-Element selbst ist, sodass nur der vorgesehene Header- Transition-Pfad neu vermisst.

Zusätzlich determineSizesAndPositions() im bestehenden Click-Timeout- Handler tatsächlich aufrufen (die bisherige Anweisung war eine wirkungslose Referenz). Das Öffnen/Schließen von Untermenüs braucht weiterhin diese einmalige verzögerte Neuvermessung nach der konfigurierten Wartezeit und darf nicht auf bubbled transitionend- Events von Nachfahren angewiesen sein.